### PR TITLE
Added Median of Medians algo for faster evaluation

### DIFF
--- a/SharpIR.cpp
+++ b/SharpIR.cpp
@@ -80,7 +80,7 @@ void SharpIR::sort(int a[], int size) {
 // Read distance and compute it
 int SharpIR::distance() {
 
-    int ir_val[NB_SAMPLE];
+    int ir_val[NB_SAMPLE] = {};
     int distanceCM;
     float current;
 
@@ -90,17 +90,22 @@ int SharpIR::distance() {
         ir_val[i] = analogRead(_irPin);
     }
     
-    // Sort it 
-    sort(ir_val,NB_SAMPLE);
-
+    // Get the approx median
+    int median;
+    if(USE_MEDOFMEDIANS){
+        median = medianOfMedians(ir_val, NB_SAMPLE);
+    }else{
+        sort(ir_val, NB_SAMPLE);
+        median = ir_val[NB_SAMPLE/2];
+    }
     
     if (_model==1080) {
         
         // Different expressions required as the Photon has 12 bit ADCs vs 10 bit for Arduinos
         #ifdef ARDUINO
-          distanceCM = 29.988 * pow(map(ir_val[NB_SAMPLE / 2], 0, 1023, 0, 5000)/1000.0, -1.173);
+          distanceCM = 29.988 * pow(map(median, 0, 1023, 0, 5000)/1000.0, -1.173);
         #elif defined(SPARK)
-          distanceCM = 29.988 * pow(map(ir_val[NB_SAMPLE / 2], 0, 4095, 0, 5000)/1000.0, -1.173);
+          distanceCM = 29.988 * pow(map(median, 0, 4095, 0, 5000)/1000.0, -1.173);
         #endif
 
     } else if (_model==20150){
@@ -110,26 +115,26 @@ int SharpIR::distance() {
         
         // Different expressions required as the Photon has 12 bit ADCs vs 10 bit for Arduinos
         #ifdef ARDUINO
-          distanceCM = 60.374 * pow(map(ir_val[NB_SAMPLE / 2], 0, 1023, 0, 5000)/1000.0, -1.16);
+          distanceCM = 60.374 * pow(map(median, 0, 1023, 0, 5000)/1000.0, -1.16);
         #elif defined(SPARK)
-          distanceCM = 60.374 * pow(map(ir_val[NB_SAMPLE / 2], 0, 4095, 0, 5000)/1000.0, -1.16);
+          distanceCM = 60.374 * pow(map(median, 0, 4095, 0, 5000)/1000.0, -1.16);
         #endif
 
     } else if (_model==430){
 
         // Different expressions required as the Photon has 12 bit ADCs vs 10 bit for Arduinos
         #ifdef ARDUINO
-          distanceCM = 12.08 * pow(map(ir_val[NB_SAMPLE / 2], 0, 1023, 0, 5000)/1000.0, -1.058);
+          distanceCM = 12.08 * pow(map(median, 0, 1023, 0, 5000)/1000.0, -1.058);
         #elif defined(SPARK)
-          distanceCM = 12.08 * pow(map(ir_val[NB_SAMPLE / 2], 0, 4095, 0, 5000)/1000.0, -1.058);
+          distanceCM = 12.08 * pow(map(median, 0, 4095, 0, 5000)/1000.0, -1.058);
         #endif
         
     } else if (_model==100500){
         
         #ifdef ARDUINO
-          current = map(ir_val[NB_SAMPLE / 2], 0, 1023, 0, 5000);
+          current = map(median, 0, 1023, 0, 5000);
         #elif defined(SPARK)
-          current = map(ir_val[NB_SAMPLE / 2], 0, 4095, 0, 5000);
+          current = map(median, 0, 4095, 0, 5000);
         #endif
         // use the inverse number of distance like in the datasheet (1/L)
         // y = mx + b = 137500*x + 1125 
@@ -146,6 +151,36 @@ int SharpIR::distance() {
     return distanceCM;
 }
 
+int SharpIR::medianOfMedians(int a[], int size){
+  int numMedians = size / 5;
+  int* medians = new int[numMedians];
+  for(int i = 0; i < numMedians; i++){
+    partialSort(a, i * 5, i * 5 + 4);
+    medians[i] = a[i * 5 + 2];
+  }
+  sort(medians, numMedians);
+  int ans = medians[numMedians/2];
+  delete [] medians;
+  medians = nullptr;
+  return ans;
+}
 
+// Sort a partial array
+void SharpIR::partialSort(int a[], int min, int max) {
+    int t;
+    bool flag;
+    for(int i=min; i<max; i++) {
+        flag = true;
+        for(int o=min; o<(max-i); o++) {
+            if(a[o] > a[o+1]) {
+                t = a[o];
+                a[o] = a[o+1];
+                a[o+1] = t;
+                flag = false;
+            }
+        }
+        if (flag) break;
+    }
+}
 
 

--- a/SharpIR.h
+++ b/SharpIR.h
@@ -7,6 +7,8 @@
 	
     Version : 1.0 : Guillaume Rico
 
+    Version : 1.2 : Archery2000
+
 	https://github.com/guillaume-rico/SharpIR
 
 */
@@ -15,7 +17,7 @@
 #define SharpIR_h
 
 #define NB_SAMPLE 25
-#define USE_MEDOFMEDIANS true
+#define USE_MEDOFMEDIANS false
 
 #ifdef ARDUINO
   #include "Arduino.h"

--- a/SharpIR.h
+++ b/SharpIR.h
@@ -15,6 +15,7 @@
 #define SharpIR_h
 
 #define NB_SAMPLE 25
+#define USE_MEDOFMEDIANS true
 
 #ifdef ARDUINO
   #include "Arduino.h"
@@ -35,6 +36,8 @@ class SharpIR
     
     int _irPin;
     long _model;
+    void partialSort(int a[], int min, int max);
+    int medianOfMedians(int a[], int size);
 };
 
 #endif


### PR DESCRIPTION
At the moment the sort to find the median has an O(n^2) complexity. Utilising a Median of Medians instead gives you the approximate median at O(n) time instead, which brings necessary performance benefits in certain use cases. Added the Medians of Medians algorithm as well as a boolean constant in SharpIR.h to choose which algo to use.